### PR TITLE
str(partner) for genericxls2pivot

### DIFF
--- a/account_move_csv_import/wizard/account_move_import.py
+++ b/account_move_csv_import/wizard/account_move_import.py
@@ -460,11 +460,16 @@ class AccountMoveImport(models.TransientModel):
                 account = str(int(account))
             elif isinstance(account, int):
                 account = str(account)
+            partner = row[3].value
+            if isinstance(partner, float):
+                partner = str(int(partner))
+            elif isinstance(partner, int):
+                partner = str(partner)
             vals = {
                 'date': datetime(*xlrd.xldate_as_tuple(row[0].value, wb.datemode)),
                 'journal': row[1].value,
                 'account': account,
-                'partner': row[3].value or False,
+                'partner': partner or False,
                 'analytic': row[4].value or False,
                 'name': row[5].value,
                 'debit': row[6].value,


### PR DESCRIPTION
because the partner code may only be numbers that Excel considers numeric or that the user has not formatted correctly