### PR TITLE
[14.0][IMP] account_move_csv_import: add field date_maturity only for CSV and XLSX

### DIFF
--- a/account_move_csv_import/wizard/import_move.py
+++ b/account_move_csv_import/wizard/import_move.py
@@ -86,6 +86,7 @@ class AccountMoveImport(models.TransientModel):
     file_with_header = fields.Boolean(
         string='Has Header Line',
         help="Indicate if the first line is a header line and should be ignored.")
+    include_date_maturity = fields.Boolean('Include Date Maturity')
 
     @api.onchange('file_format')
     def file_format_change(self):
@@ -329,7 +330,7 @@ class AccountMoveImport(models.TransientModel):
         fieldnames = [
             'date', 'journal', 'account', 'partner',
             'analytic', 'name', 'debit', 'credit',
-            'ref', 'reconcile_ref', 'move_name',
+            'ref', 'reconcile_ref', 'move_name', 'date_maturity',
             ]
         first_line = fileobj.readline().decode()
         dialect = unicodecsv.Sniffer().sniff(first_line)
@@ -356,7 +357,19 @@ class AccountMoveImport(models.TransientModel):
                 raise UserError(_(
                     "Date parsing error: '%s' in line %s does not match "
                     "date format '%s'.") % (date_str, i, self.date_format))
-
+            if self.include_date_maturity:
+                date_maturity_str = l['date_maturity']
+                if date_maturity_str:
+                    try:
+                        date_maturity = datetime.strptime(date_maturity_str, self.date_format)
+                    except ValueError:
+                        raise UserError(_(
+                            "Date Maturity parsing error: '%s' in line %s does not match "
+                            "date format '%s'.") % (date_maturity_str, i, self.date_format))
+                else:
+                    date_maturity = False
+            else:
+                date_maturity = False
             vals = {
                 'journal': l['journal'],
                 'account': l['account'],
@@ -367,6 +380,7 @@ class AccountMoveImport(models.TransientModel):
                 'ref': l.get('ref', ''),
                 'reconcile_ref': l.get('reconcile_ref', ''),
                 'move_name': l.get('move_name', ''),
+                'date_maturity': date_maturity,
                 'line': i,
                 }
             if l['analytic']:
@@ -390,6 +404,10 @@ class AccountMoveImport(models.TransientModel):
             if not [item for item in row if item.value]:
                 # skip empty line
                 continue
+            if self.include_date_maturity:
+                date_maturity = row[12].value
+            else:
+                date_maturity = False
             vals = {
                 'date': row[0].value,
                 'journal': row[1].value,
@@ -403,6 +421,7 @@ class AccountMoveImport(models.TransientModel):
                 'reconcile_ref': len(row) > 9 and row[9].value or '',
                 'analytic_tags': len(row) > 10 and row[10].value or '',
                 'move_name': len(row) > 11 and row[11].value or '',
+                'date_maturity': date_maturity,
                 'line': i,
                 }
             res.append(vals)
@@ -741,6 +760,10 @@ class AccountMoveImport(models.TransientModel):
             'import_reconcile': pivot_line.get('reconcile_ref'),
             'import_external_id': '%s-%s' % (sequence, pivot_line.get('line')),
             }
+        # Adding date_maturity only if it exists in pivot_line
+        # This validation is temporary as date_maturity implementation is currently for CSV and XLSX file types only
+        if 'date_maturity' in pivot_line:
+            vals['date_maturity'] = pivot_line['date_maturity']
         return vals
 
     def reconcile_move_lines(self, moves):

--- a/account_move_csv_import/wizard/import_move_view.xml
+++ b/account_move_csv_import/wizard/import_move_view.xml
@@ -20,6 +20,7 @@
                 <field name="file_encoding" attrs="{'invisible': [('file_format', 'not in', ('fec_txt', 'quadra'))], 'required': [('file_format', 'in', ('fec_txt', 'quadra'))]}"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="post_move" />
+                <field name="include_date_maturity" attrs="{'invisible': [('file_format', 'not in', ('genericxlsx', 'genericcsv'))]}"/>
                 <field name="force_journal_id" attrs="{'required': [('force_journal_required', '=', True)]}"/>
                 <field name="force_move_date" attrs="{'required': [('force_move_date_required', '=', True)]}"/>
                 <field name="force_move_ref" />
@@ -56,6 +57,7 @@
                         <li>Ref (used as Journal Entry Ref)</li>
                         <li>Reconcile ref (used for reconciliation after import)</li>
                         <li>Journal entry number</li>
+                        <li>Date Maturity (DD/MM/YYYY or configurable)</li>
                         </ol></li>
                     <li><em>Encoding</em>: UTF-8</li>
                     <li><em>Field separator</em>: auto-detected</li>
@@ -78,6 +80,7 @@
                     J. Reconcile Ref (used for reconciliation after import)<br/>
                     K. Analytic Tags (separated by coma)<br/>
                     L. Journal Entry Number<br/>
+                    M. Date Maturity (DD/MM/YYYY or configurable)<br/>
                 </p>
             </div>
 


### PR DESCRIPTION
cc @marcelsavegnago

Added the `date_maturity` field to the `account.move.csv.import` model, allowing for smoother imports. Additionally, introduced a boolean field enabling users to indicate whether they wish to import with maturity dates. Initially implemented for CSV and XLSX file formats.