### PR TITLE
[14] Always convert ref to string for xlsx format

### DIFF
--- a/account_move_csv_import/wizard/import_move.py
+++ b/account_move_csv_import/wizard/import_move.py
@@ -393,7 +393,7 @@ class AccountMoveImport(models.TransientModel):
                 'date': row[0].value,
                 'journal': row[1].value,
                 'account': str(row[2].value),
-                'partner': row[3].value or False,
+                'partner': row[3].value and str(row[3].value) or False,
                 'analytic': row[4].value or False,
                 'name': row[5].value,
                 'debit': row[6].value,


### PR DESCRIPTION
@alexis-via Trivial PR
Problem is when ref is a number, like if you put the odoo id in the ref field, if excel is badly converted, Odoo won't find the ref.
=> Do as we already do for the account code : convert to string anyway.

Please merge it if agreed