### PR TITLE
[18.0][IMP] account_move_csv_import: support 'date_maturity' field in CSV, ODS, XLS, and XLSX

### DIFF
--- a/account_move_csv_import/wizard/account_move_import.py
+++ b/account_move_csv_import/wizard/account_move_import.py
@@ -109,7 +109,10 @@ class AccountMoveImport(models.TransientModel):
     file_with_header = fields.Boolean(
         string='Has Header Line',
         help="Indicate if the first line is a header line and should be ignored.")
-
+    use_date_maturity = fields.Boolean(
+        string='Use Date Maturity',
+        help='If enabled, the import will use the date maturity field from the file.')
+        
     @api.depends('file_format')
     def _compute_force_required(self):
         for wiz in self:
@@ -363,7 +366,7 @@ class AccountMoveImport(models.TransientModel):
         fieldnames = [
             'date', 'journal', 'account', 'partner',
             'analytic', 'name', 'debit', 'credit',
-            'ref', 'reconcile_ref', 'move_name',
+            'ref', 'reconcile_ref', 'move_name', 'date_maturity',
             ]
         # I use utf-8-sig instead of utf-8 to transparently handle BOM
         # https://en.wikipedia.org/wiki/Byte_order_mark
@@ -399,6 +402,7 @@ class AccountMoveImport(models.TransientModel):
                     'ref': l.get('ref', ''),
                     'reconcile_ref': l.get('reconcile_ref', ''),
                     'move_name': l.get('move_name', ''),
+                    'date_maturity': l.get('date_maturity', ''),
                     'line': i,
                     }
                 if l['analytic']:
@@ -445,6 +449,7 @@ class AccountMoveImport(models.TransientModel):
                 'ref': len(row) > 8 and row[8].value or '',
                 'reconcile_ref': len(row) > 9 and row[9].value or '',
                 'move_name': len(row) > 10 and row[10].value or '',
+                'date_maturity': len(row) > 11 and row[11].value or False,
                 'line': i,
                 }
             res.append(vals)
@@ -481,6 +486,7 @@ class AccountMoveImport(models.TransientModel):
                 'credit': row[7].value,
                 'ref': len(row) > 8 and row[8].value or '',
                 'reconcile_ref': len(row) > 9 and row[9].value or '',
+                'date_maturity': len(row) > 11 and row[11].value and datetime(*xlrd.xldate_as_tuple(row[11].value, wb.datemode)) or False,
                 'line': i,
                 }
             res.append(vals)
@@ -506,6 +512,7 @@ class AccountMoveImport(models.TransientModel):
             ('credit', rows.fields.FloatField),
             ('ref', rows.fields.TextField),
             ('reconcile_ref', rows.fields.TextField),
+            ('date_maturity', rows.fields.DateField),
             ])
 
         sh = rows.import_from_ods(fileobj.name, fields=fields_ods, skip_header=False)
@@ -528,6 +535,7 @@ class AccountMoveImport(models.TransientModel):
                 'credit': row.credit,
                 'ref': row.ref,
                 'reconcile_ref': row.reconcile_ref,
+                'date_maturity': getattr(row, 'date_maturity', False),
                 'line': i,
                 }
             res.append(vals)
@@ -883,6 +891,19 @@ class AccountMoveImport(models.TransientModel):
             'import_reconcile': pivot_line.get('reconcile_ref'),
             'import_external_id': f"{sequence}-{pivot_line.get('line')}",
             }
+        
+        if self.use_date_maturity and pivot_line.get('date_maturity'):
+            try:
+                if isinstance(pivot_line['date_maturity'], str):
+                    vals['date_maturity'] = datetime.strptime(
+                        pivot_line['date_maturity'], self.date_format)
+                else:
+                    vals['date_maturity'] = pivot_line['date_maturity']
+            except Exception:
+                logger.warning(
+                    "Could not parse date maturity '%s' for line %s",
+                    pivot_line['date_maturity'], pivot_line.get('line'))
+        
         return vals
 
     def reconcile_move_lines(self, moves):

--- a/account_move_csv_import/wizard/account_move_import_view.xml
+++ b/account_move_csv_import/wizard/account_move_import_view.xml
@@ -18,6 +18,7 @@
                 <field name="filename" invisible="1"/>
                 <field name="file_format" />
                 <field name="post_move" />
+                <field name="use_date_maturity"/>
                 <field name="file_encoding" invisible="file_format not in ('fec_txt', 'quadra', 'genericcsv')" required="file_format in ('fec_txt', 'quadra', 'genericcsv')"/>
                 <field name="delimiter" invisible="file_format != 'genericcsv'" required="file_format == 'genericcsv'"/>
                 <field name="date_format" invisible="file_format != 'genericcsv'"/>
@@ -59,6 +60,7 @@
                         <li>Ref (used as Journal Entry Ref)</li>
                         <li>Reconcile ref (used for reconciliation after import)</li>
                         <li>Journal entry number</li>
+                        <li>Due Date (DD/MM/YYYY or configurable, optional)</li>
                         </ol></li>
                   </ul>
               </div>
@@ -76,6 +78,7 @@
                     I. Ref (used as Journal Entry Ref)<br/>
                     J. Reconcile Ref (used for reconciliation after import)<br/>
                     K. Journal Entry Number<br/>
+                    L. Due Date (must be a date field in the spreadsheet, optional)<br/>
                 </p>
             </div>
 


### PR DESCRIPTION
cc @marcelsavegnago

- Added support for importing the `date_maturity` field in the `account.move.csv.import` model to improve flexibility when handling payment terms. 
- Introduced a boolean field allowing users to choose whether to import maturity dates.
- Support has been implemented for CSV, ODS, XLS, and XLSX file formats.